### PR TITLE
added pg_timetable executable to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Binaries for programs and plugins
+pg_timetable
 *.exe
 *.exe~
 *.dll


### PR DESCRIPTION
added pg_timetable executable as produced by go build on linux and probably mac os to .gitignore