### PR TITLE
fix #150, use client_name in job_add function

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Create a Job with the `timetable.job_add` function. With this function you can a
 | :----------------------- | :------ | :----------------------------------------------- |:---------|
 | `task_name`     | `text`  | The name of the Task ||
 | `task_function` | `text`  | The function wich will be executed. ||
+| `client_name`   | `text`  | Specifies which client should execute the chain. Set this to `NULL` to allow any client. |
 | `task_type`     | `text`  | Type of the function `SQL`,`SHELL` and `BUILTIN` |SQL|
 | `run_at`        | `timetable.cron`  | Time schedule in сron syntax. `NULL` stands for `'* * * * *'`     |NULL|
 | `max_instances` | `integer` | The amount of instances that this chain may have running at the same time. |NULL|

--- a/internal/pgengine/sql_job_functions.go
+++ b/internal/pgengine/sql_job_functions.go
@@ -200,14 +200,16 @@ INSERT INTO timetable.chain_execution_config (
     run_at, 
     max_instances, 
     live,
-    self_destruct 
+    self_destruct,
+    client_name
 ) SELECT 
     v_chain_id, 
     ''chain_'' || v_chain_id, 
     run_at,
     max_instances, 
     live, 
-    self_destruct
+    self_destruct,
+    client_name
 FROM cte_chain
 RETURNING chain_execution_config 
 ' LANGUAGE 'sql';


### PR DESCRIPTION
Pass client_name along to chain_execution_config.

Add client_name to README.md, under "3.4 Example Functions".