### PR TITLE
[+] Built-in `SendMail` task now can read attachments data from parameters

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -132,6 +132,7 @@ Kind
                 "toaddr":       ["recipient@example.com"],
                 "subject":      "pg_timetable - No Reply",
                 "attachment":   ["/temp/attachments/Report.pdf","config.yaml"],
+                "attachmentdata": [{"name": "File.txt", "base64data": "RmlsZSBDb250ZW50"}],
                 "msgbody":      "<h2>Hello User,</h2> <p>check some attachments!</p>",
                 "contenttype":   "text/html; charset=UTF-8"
             }'::jsonb

--- a/internal/tasks/mail.go
+++ b/internal/tasks/mail.go
@@ -1,25 +1,34 @@
 package tasks
 
 import (
+	"bytes"
 	"context"
 
 	gomail "github.com/ory/mail/v3"
 )
 
+// Attachment file type
+// Has pair: name and content (base64-encoded) of attachment file
+type EmailAttachmentData struct {
+	Name       string `json:"name"`
+	Base64Data []byte `json:"base64data"`
+}
+
 // EmailConn structure represents a connection to a mail server and mail fields
 type EmailConn struct {
-	Username    string   `json:"username"`
-	Password    string   `json:"password"`
-	ServerHost  string   `json:"serverhost"`
-	ServerPort  int      `json:"serverport"`
-	SenderAddr  string   `json:"senderaddr"`
-	CcAddr      []string `json:"ccaddr"`
-	BccAddr     []string `json:"bccaddr"`
-	ToAddr      []string `json:"toaddr"`
-	Subject     string   `json:"subject"`
-	MsgBody     string   `json:"msgbody"`
-	Attachments []string `json:"attachment"`
-	ContentType string   `json:"contenttype"`
+	Username       string                `json:"username"`
+	Password       string                `json:"password"`
+	ServerHost     string                `json:"serverhost"`
+	ServerPort     int                   `json:"serverport"`
+	SenderAddr     string                `json:"senderaddr"`
+	CcAddr         []string              `json:"ccaddr"`
+	BccAddr        []string              `json:"bccaddr"`
+	ToAddr         []string              `json:"toaddr"`
+	Subject        string                `json:"subject"`
+	MsgBody        string                `json:"msgbody"`
+	Attachments    []string              `json:"attachment"`
+	AttachmentData []EmailAttachmentData `json:"attachmentdata"`
+	ContentType    string                `json:"contenttype"`
 }
 
 // Dialer implements DialAndSend function for mailer
@@ -64,6 +73,11 @@ func SendMail(ctx context.Context, conn EmailConn) error {
 	//attach multiple documents
 	for _, attachment := range conn.Attachments {
 		mail.Attach(attachment)
+	}
+
+	// Attach file with contents
+	for _, attachmentData := range conn.AttachmentData {
+		mail.AttachReader(attachmentData.Name, bytes.NewReader([]byte(attachmentData.Base64Data)))
 	}
 	// Send Mail
 	dialer := NewDialer(conn.ServerHost, conn.ServerPort, conn.Username, conn.Password)

--- a/internal/tasks/mail_test.go
+++ b/internal/tasks/mail_test.go
@@ -31,5 +31,9 @@ func TestTaskSendMail(t *testing.T) {
 		CcAddr:      []string{"cc@example.com"},
 		BccAddr:     []string{"bcc@example.com"},
 		Attachments: []string{"mail.go"},
+		AttachmentData: []EmailAttachmentData{{
+			Name:       "File1.txt",
+			Base64Data: []byte("RmlsZSBDb250ZW50"), // "File Content" base64-encoded
+		}},
 	}), "Sending email with required json input should succeed")
 }

--- a/samples/Mail.sql
+++ b/samples/Mail.sql
@@ -15,17 +15,18 @@ BEGIN
 	RETURNING task_id INTO v_mail_task_id;
 
 	-- Create the parameters for the SensMail task
-		-- "username":	  The username used for authenticating on the mail server
-		-- "password":    The password used for authenticating on the mail server
-		-- "serverhost":  The IP address or hostname of the mail server
-		-- "serverport":  The port of the mail server
-		-- "senderaddr":  The email that will appear as the sender
-		-- "ccaddr":	  String array of the recipients(Cc) email addresses
-		-- "bccaddr":	  String array of the recipients(Bcc) email addresses
-		-- "toaddr":      String array of the recipients(To) email addresses
-		-- "subject":	  Subject of the email
-		-- "attachment":  String array of the attachments
-		-- "msgbody":	  The body of the email
+		-- "username":	      The username used for authenticating on the mail server
+		-- "password":        The password used for authenticating on the mail server
+		-- "serverhost":      The IP address or hostname of the mail server
+		-- "serverport":      The port of the mail server
+		-- "senderaddr":      The email that will appear as the sender
+		-- "ccaddr":	      String array of the recipients(Cc) email addresses
+		-- "bccaddr":	      String array of the recipients(Bcc) email addresses
+		-- "toaddr":          String array of the recipients(To) email addresses
+		-- "subject":	      Subject of the email
+		-- "attachment":      String array of the attachments (local file)
+		-- "attachmentdata":  Pairs of name and base64-encoded content
+		-- "msgbody":	      The body of the email
 
 	INSERT INTO timetable.parameter (task_id, order_id, value)
 		VALUES (v_mail_task_id, 1, '{
@@ -39,6 +40,7 @@ BEGIN
 				"toaddr":       ["recipient@example.com"],
 				"subject": 		"pg_timetable - No Reply",
 				"attachment":   ["D:\\Go stuff\\Books\\Concurrency in Go.pdf","D:\\Go stuff\\Books\\The Way To Go.pdf"],
+                "attachmentdata": [{"name": "File.txt", "base64data": "RmlsZSBDb250ZW50"}],
 				"msgbody":		"<b>Hello User,</b> <p>I got some Go books for you enjoy</p> <i>pg_timetable</i>!"
 				}'::jsonb);
 	


### PR DESCRIPTION
(uses pairs of name and base64-encoded content)