### PR TITLE
Make cleaning of stale `run_status` rows by schedule (every minute)

### DIFF
--- a/internal/pgengine/bootstrap.go
+++ b/internal/pgengine/bootstrap.go
@@ -129,8 +129,9 @@ func (pge *PgEngine) getPgxConnConfig() *pgxpool.Config {
 	// in the worst scenario we need separate connections for each of workers,
 	// separate connection for Scheduler.retrieveChainsAndRun(),
 	// separate connection for Scheduler.retrieveIntervalChainsAndRun(),
+	// separate connection for Scheduler.cleanStaleRunStatus(),
 	// and another connection for LogHook.send()
-	connConfig.MaxConns = int32(pge.Resource.CronWorkers) + int32(pge.Resource.IntervalWorkers) + 3
+	connConfig.MaxConns = int32(pge.Resource.CronWorkers) + int32(pge.Resource.IntervalWorkers) + 4
 	connConfig.ConnConfig.RuntimeParams["application_name"] = "pg_timetable"
 	connConfig.ConnConfig.OnNotice = func(c *pgconn.PgConn, n *pgconn.Notice) {
 		pge.l.WithField("severity", n.Severity).WithField("notice", n.Message).Info("Notice received")

--- a/internal/scheduler/interval_chain.go
+++ b/internal/scheduler/interval_chain.go
@@ -53,6 +53,12 @@ func (sch *Scheduler) reschedule(ctx context.Context, ichain IntervalChain) {
 	}
 }
 
+func (sch *Scheduler) cleanStaleRunStatus(ctx context.Context) {
+	sch.deleteStaleRunStatusMutex.Lock()
+	defer sch.deleteStaleRunStatusMutex.Unlock()
+	sch.pgengine.CleanStaleRunStatus(ctx)
+}
+
 func (sch *Scheduler) retrieveIntervalChainsAndRun(ctx context.Context) {
 	sch.intervalChainMutex.Lock()
 	ichains := []IntervalChain{}


### PR DESCRIPTION
Addressed #370

I have a question abound DEAD status, should we clean such rows or not?