### PR TITLE
[+] trim possible leading or trailing white space from the command

### DIFF
--- a/internal/scheduler/shell.go
+++ b/internal/scheduler/shell.go
@@ -28,7 +28,8 @@ var Cmd commander = realCommander{}
 // ExecuteProgramCommand executes program command and returns status code, output and error if any
 func (sch *Scheduler) ExecuteProgramCommand(ctx context.Context, command string, paramValues []string) (code int, stdout string, stderr error) {
 
-	if strings.TrimSpace(command) == "" {
+	command = strings.TrimSpace(command)
+	if command == "" {
 		return -1, "", errors.New("Program command cannot be empty")
 	}
 	if len(paramValues) == 0 { //mimic empty param


### PR DESCRIPTION
Having white space in the command is a silly mistake, but happens to all of us (particularly when doing some copy-paste).

And when looking at the error in the console, it's easy to miss that the problem is the whitespace:

```bash
2022-04-22 16:59:37.969 [ERROR] [chain:21] [task:20] [error:fork/exec ./my_script.sh : no such file or directory] Task execution failed
```
(note the white space between "./my_script.sh" and ":"