### PR TITLE
[+] docs: clarify how external commands are called

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -16,7 +16,7 @@ Currently, there are three different kinds of commands:
     SQL snippet. Starting a cleanup, refreshing a materialized view or processing data.
 
 ``PROGRAM``
-    External Command. Anything that can be called as an external binary, including shells, e.g. ``bash``, ``pwsh``, etc.
+    External Command. Anything that can be called as an external binary, including shells, e.g. ``bash``, ``pwsh``, etc. The external command will be called using golang's `exec.CommandContext <https://pkg.go.dev/os/exec#CommandContext>`_. 
 
 ``BUILTIN``
     Internal Command. A prebuilt functionality included in **pg_timetable**. These include:


### PR DESCRIPTION
Some aspects are not clear in the docs. For instance:

- how is the command called?
- what is the current working directory? (this is important for relative paths)
- what is the PATH variable?

The reference to golang's docs allows the user find more information about these details.