### PR TITLE
Update ddl.sql

### DIFF
--- a/internal/pgengine/sql/ddl.sql
+++ b/internal/pgengine/sql/ddl.sql
@@ -109,6 +109,7 @@ CREATE UNLOGGED TABLE timetable.active_session(
     client_pid  BIGINT  NOT NULL,
     client_name TEXT    NOT NULL,
     server_pid  BIGINT  NOT NULL,
+    client_addr INET  NOT NULL,
     started_at  TIMESTAMPTZ DEFAULT now()
 );
 
@@ -187,7 +188,7 @@ BEGIN
     PERFORM 1
         FROM timetable.active_session s
         WHERE
-            s.client_pid <> worker_pid
+            s.client_addr <> inet_client_addr()
             AND s.client_name = worker_name
         LIMIT 1;
     IF FOUND THEN
@@ -195,7 +196,7 @@ BEGIN
         RETURN FALSE;
     END IF;
     -- insert current session information
-    INSERT INTO timetable.active_session(client_pid, client_name, server_pid) VALUES (worker_pid, worker_name, pg_backend_pid());
+    INSERT INTO timetable.active_session(client_pid, client_name, server_pid, client_addr) VALUES (worker_pid, worker_name, pg_backend_pid(), inet_client_addr());
     RETURN TRUE;
 END;
 $CODE$


### PR DESCRIPTION
client_pid(worker_pid)

The server running pg_timetable may be different, but coincidentally the pid may be the same.
At my docker enviroment, serveral  same pid(differnt docker constainer)  happended.

Duplicate execution can be prevented by adding the client_addr column as shown below.


SQL> select * from timetable.active_sessions
client_id 
---------  -------------------------------------------------------------------
14	pg_timetable	28417	167.71.214.34	2022-08-07 14:12:24.333 +0900
14	pg_timetable	28418	167.71.214.34	2022-08-07 14:12:24.366 +0900
14	pg_timetable	28422	128.199.132.200	2022-08-07 14:12:29.563 +0900
14	pg_timetable	28423	128.199.132.200	2022-08-07 14:12:29.589 +0900