### PR TITLE
[*] `cron_split_to_arrays()` raises error for incorrect range and step values, closes #527

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Unit Test",
             "type": "shell",
-            "command": "go test -failfast -timeout=300s -parallel=1 ./${relativeFileDirname}/... -coverprofile='coverage.out' -json | tparse -all",
+            "command": "go test -failfast -timeout=300s -parallel=1 .${pathSeparator}${relativeFileDirname}${pathSeparator}... -coverprofile='coverage.out' -json | tparse -all",
             "problemMatcher": [
                 "$go"
             ],

--- a/internal/pgengine/bootstrap.go
+++ b/internal/pgengine/bootstrap.go
@@ -73,8 +73,8 @@ func (pge *PgEngine) Getsid() int32 {
 	return pge.sid
 }
 
-var sqls = []string{sqlDDL, sqlJSONSchema, sqlCronFunctions, sqlJobFunctions}
-var sqlNames = []string{"DDL", "JSON Schema", "Cron Functions", "Job Functions"}
+var sqls = []string{sqlInit, sqlCron, sqlDDL, sqlJSONSchema, sqlJobFunctions}
+var sqlNames = []string{"Schema Init", "Cron Functions", "Tables and Views", "JSON Schema", "Job Functions"}
 
 // New opens connection and creates schema
 func New(ctx context.Context, cmdOpts config.CmdOptions, logger log.LoggerHookerIface) (*PgEngine, error) {

--- a/internal/pgengine/migration.go
+++ b/internal/pgengine/migration.go
@@ -114,7 +114,13 @@ var Migrations func() migrator.Option = func() migrator.Option {
 				return ExecuteMigrationScript(ctx, tx, "00436.sql")
 			},
 		},
-		// adding new migration here, update "timetable"."migration" in "sql/ddl.sql"
+		&migrator.Migration{
+			Name: "00534 Use cron_split_to_arrays() in cron domain check",
+			Func: func(ctx context.Context, tx pgx.Tx) error {
+				return ExecuteMigrationScript(ctx, tx, "00534.sql")
+			},
+		},
+		// adding new migration here, update "timetable"."migration" in "sql/init.sql"
 		// and "dbapi" variable in main.go!
 
 		// &migrator.Migration{

--- a/internal/pgengine/pgengine_test.go
+++ b/internal/pgengine/pgengine_test.go
@@ -97,7 +97,7 @@ func TestInitAndTestConfigDBConnection(t *testing.T) {
 			"SELECT '0 1 1 * 1,2' :: timetable.cron",
 			"SELECT '0 1 1 * 1,2,3' :: timetable.cron",
 			"SELECT '0 1 * * 1/4' :: timetable.cron",
-			"SELECT '0 * * 0 1-4' :: timetable.cron",
+			"SELECT '0 * * 7 1-4' :: timetable.cron",
 			"SELECT '0 * * * 2/4' :: timetable.cron",
 			"SELECT '* * * * *' :: timetable.cron",
 			"SELECT '*/2 */2 * * *' :: timetable.cron",

--- a/internal/pgengine/sql/cron.sql
+++ b/internal/pgengine/sql/cron.sql
@@ -131,6 +131,16 @@ CREATE OR REPLACE FUNCTION timetable.cron_runs(
     ORDER BY 1 ASC;
 $$ LANGUAGE SQL STRICT;
 
+CREATE DOMAIN timetable.cron AS TEXT CHECK(
+    VALUE = '@reboot'
+    OR substr(VALUE, 1, 6) IN ('@every', '@after') 
+       AND (substr(VALUE, 7) :: INTERVAL) IS NOT NULL
+    OR VALUE ~ '^(((\d+,)+\d+|(\d+(\/|-)\d+)|(\*(\/|-)\d+)|\d+|\*) +){4}(((\d+,)+\d+|(\d+(\/|-)\d+)|(\*(\/|-)\d+)|\d+|\*) ?)$'
+       AND timetable.cron_split_to_arrays(VALUE) IS NOT NULL
+);
+
+COMMENT ON DOMAIN timetable.cron IS 'Extended CRON-style notation with support of interval values';
+
 -- is_cron_in_time returns TRUE if timestamp is listed in cron expression
 CREATE OR REPLACE FUNCTION timetable.is_cron_in_time(
     run_at timetable.cron, 

--- a/internal/pgengine/sql/cron_functions.sql
+++ b/internal/pgengine/sql/cron_functions.sql
@@ -14,27 +14,20 @@ DECLARE
     a_range int[];
     a_split text[];
     a_res integer[];
-    allowed_range integer[];
     max_val integer;
     min_val integer;
+    dimensions constant text[] = '{"minutes", "hours", "days", "months", "days of week"}';
+    allowed_ranges constant integer[][] = '{{0,59},{0,23},{1,31},{1,12},{0,7}}';
 BEGIN
     a_element := regexp_split_to_array(cron, '\s+');
     FOR i_index IN 1..5 LOOP
         a_res := NULL;
         a_tmp := string_to_array(a_element[i_index],',');
-        CASE i_index -- 1 - mins, 2 - hours, 3 - days, 4 - weeks, 5 - DOWs
-            WHEN 1 THEN allowed_range := '{0,59}';
-            WHEN 2 THEN allowed_range := '{0,23}';
-            WHEN 3 THEN allowed_range := '{1,31}';
-            WHEN 4 THEN allowed_range := '{1,12}';
-        ELSE
-            allowed_range := '{0,7}';
-        END CASE;
         FOREACH  tmp_item IN ARRAY a_tmp LOOP
             IF tmp_item ~ '^[0-9]+$' THEN -- normal integer
                 a_res := array_append(a_res, tmp_item::int);
             ELSIF tmp_item ~ '^[*]+$' THEN -- '*' any value
-                a_range := array(select generate_series(allowed_range[1], allowed_range[2]));
+                a_range := array(select generate_series(allowed_ranges[i_index][1], allowed_ranges[i_index][2]));
                 a_res := array_cat(a_res, a_range);
             ELSIF tmp_item ~ '^[0-9]+[-][0-9]+$' THEN -- '-' range of values
                 a_range := regexp_split_to_array(tmp_item, '-');
@@ -42,7 +35,7 @@ BEGIN
                 a_res := array_cat(a_res, a_range);
             ELSIF tmp_item ~ '^[0-9]+[\/][0-9]+$' THEN -- '/' step values
                 a_range := regexp_split_to_array(tmp_item, '/');
-                a_range := array(select generate_series(a_range[1], allowed_range[2], a_range[2]));
+                a_range := array(select generate_series(a_range[1], allowed_ranges[i_index][2], a_range[2]));
                 a_res := array_cat(a_res, a_range);
             ELSIF tmp_item ~ '^[0-9-]+[\/][0-9]+$' THEN -- '-' range of values and '/' step values
                 a_split := regexp_split_to_array(tmp_item, '/');
@@ -51,7 +44,7 @@ BEGIN
                 a_res := array_cat(a_res, a_range);
             ELSIF tmp_item ~ '^[*]+[\/][0-9]+$' THEN -- '*' any value and '/' step values
                 a_split := regexp_split_to_array(tmp_item, '/');
-                a_range := array(select generate_series(allowed_range[1], allowed_range[2], a_split[2]::int));
+                a_range := array(select generate_series(allowed_ranges[i_index][1], allowed_ranges[i_index][2], a_split[2]::int));
                 a_res := array_cat(a_res, a_range);
             ELSE
                 RAISE EXCEPTION 'Value ("%") not recognized', a_element[i_index]
@@ -64,11 +57,11 @@ BEGIN
            ARRAY_AGG(x.val), MIN(x.val), MAX(x.val) INTO a_res, min_val, max_val
         FROM (
             SELECT DISTINCT UNNEST(a_res) AS val ORDER BY val) AS x;
-        IF max_val > allowed_range[2] OR min_val < allowed_range[1] THEN
-            RAISE EXCEPTION '% is out of range: %', a_res, allowed_range;
+        IF max_val > allowed_ranges[i_index][2] OR min_val < allowed_ranges[i_index][1] OR a_res IS NULL THEN
+            RAISE EXCEPTION '% is out of range % for %', tmp_item, allowed_ranges[i_index:i_index][:], dimensions[i_index];
         END IF;
         CASE i_index
-                  WHEN 1 THEN mins := a_res;
+            WHEN 1 THEN mins := a_res;
             WHEN 2 THEN hours := a_res;
             WHEN 3 THEN days := a_res;
             WHEN 4 THEN months := a_res;

--- a/internal/pgengine/sql/ddl.sql
+++ b/internal/pgengine/sql/ddl.sql
@@ -1,36 +1,3 @@
-CREATE SCHEMA timetable;
-
--- define migrations you need to apply
--- every change to this file should populate this table.
--- Version value should contain issue number zero padded followed by
--- short description of the issue\feature\bug implemented\resolved
-CREATE TABLE timetable.migration(
-    id INT8 NOT NULL,
-    version TEXT NOT NULL,
-    PRIMARY KEY (id)
-);
-
-INSERT INTO
-    timetable.migration (id, version)
-VALUES
-    (0, '00259 Restart migrations for v4'),
-    (1, '00305 Fix timetable.is_cron_in_time'),
-    (2, '00323 Append timetable.delete_job function'),
-    (3, '00329 Migration required for some new added functions'),
-    (4, '00334 Refactor timetable.task as plain schema without tree-like dependencies'),
-    (5, '00381 Rewrite active chain handling'),
-    (6, '00394 Add started_at column to active_session and active_chain tables'),
-    (7, '00417 Rename LOG database log level to INFO'),
-    (8, '00436 Add txid column to timetable.execution_log');
-
-CREATE DOMAIN timetable.cron AS TEXT CHECK(
-    substr(VALUE, 1, 6) IN ('@every', '@after') AND (substr(VALUE, 7) :: INTERVAL) IS NOT NULL
-    OR VALUE = '@reboot'
-    OR VALUE ~ '^(((\d+,)+\d+|(\d+(\/|-)\d+)|(\*(\/|-)\d+)|\d+|\*) +){4}(((\d+,)+\d+|(\d+(\/|-)\d+)|(\*(\/|-)\d+)|\d+|\*) ?)$'
-);
-
-COMMENT ON DOMAIN timetable.cron IS 'Extended CRON-style notation with support of interval values';
-
 CREATE TABLE timetable.chain (
     chain_id            BIGSERIAL   PRIMARY KEY,
     chain_name          TEXT        NOT NULL UNIQUE,

--- a/internal/pgengine/sql/init.sql
+++ b/internal/pgengine/sql/init.sql
@@ -21,4 +21,5 @@ VALUES
     (5, '00381 Rewrite active chain handling'),
     (6, '00394 Add started_at column to active_session and active_chain tables'),
     (7, '00417 Rename LOG database log level to INFO'),
-    (8, '00436 Add txid column to timetable.execution_log');
+    (8, '00436 Add txid column to timetable.execution_log'),
+    (9, '00534 Use cron_split_to_arrays() in cron domain check');

--- a/internal/pgengine/sql/init.sql
+++ b/internal/pgengine/sql/init.sql
@@ -1,0 +1,24 @@
+CREATE SCHEMA timetable;
+
+-- define migrations you need to apply
+-- every change to this file should populate this table.
+-- Version value should contain issue number zero padded followed by
+-- short description of the issue\feature\bug implemented\resolved
+CREATE TABLE timetable.migration(
+    id INT8 NOT NULL,
+    version TEXT NOT NULL,
+    PRIMARY KEY (id)
+);
+
+INSERT INTO
+    timetable.migration (id, version)
+VALUES
+    (0, '00259 Restart migrations for v4'),
+    (1, '00305 Fix timetable.is_cron_in_time'),
+    (2, '00323 Append timetable.delete_job function'),
+    (3, '00329 Migration required for some new added functions'),
+    (4, '00334 Refactor timetable.task as plain schema without tree-like dependencies'),
+    (5, '00381 Rewrite active chain handling'),
+    (6, '00394 Add started_at column to active_session and active_chain tables'),
+    (7, '00417 Rename LOG database log level to INFO'),
+    (8, '00436 Add txid column to timetable.execution_log');

--- a/internal/pgengine/sql/migrations/00534.sql
+++ b/internal/pgengine/sql/migrations/00534.sql
@@ -1,0 +1,86 @@
+CREATE OR REPLACE FUNCTION timetable.cron_split_to_arrays(
+    cron text,
+    OUT mins integer[],
+    OUT hours integer[],
+    OUT days integer[],
+    OUT months integer[],
+    OUT dow integer[]
+) RETURNS record AS $$
+DECLARE
+    a_element text[];
+    i_index integer;
+    a_tmp text[];
+    tmp_item text;
+    a_range int[];
+    a_split text[];
+    a_res integer[];
+    max_val integer;
+    min_val integer;
+    dimensions constant text[] = '{"minutes", "hours", "days", "months", "days of week"}';
+    allowed_ranges constant integer[][] = '{{0,59},{0,23},{1,31},{1,12},{0,7}}';
+BEGIN
+    a_element := regexp_split_to_array(cron, '\s+');
+    FOR i_index IN 1..5 LOOP
+        a_res := NULL;
+        a_tmp := string_to_array(a_element[i_index],',');
+        FOREACH  tmp_item IN ARRAY a_tmp LOOP
+            IF tmp_item ~ '^[0-9]+$' THEN -- normal integer
+                a_res := array_append(a_res, tmp_item::int);
+            ELSIF tmp_item ~ '^[*]+$' THEN -- '*' any value
+                a_range := array(select generate_series(allowed_ranges[i_index][1], allowed_ranges[i_index][2]));
+                a_res := array_cat(a_res, a_range);
+            ELSIF tmp_item ~ '^[0-9]+[-][0-9]+$' THEN -- '-' range of values
+                a_range := regexp_split_to_array(tmp_item, '-');
+                a_range := array(select generate_series(a_range[1], a_range[2]));
+                a_res := array_cat(a_res, a_range);
+            ELSIF tmp_item ~ '^[0-9]+[\/][0-9]+$' THEN -- '/' step values
+                a_range := regexp_split_to_array(tmp_item, '/');
+                a_range := array(select generate_series(a_range[1], allowed_ranges[i_index][2], a_range[2]));
+                a_res := array_cat(a_res, a_range);
+            ELSIF tmp_item ~ '^[0-9-]+[\/][0-9]+$' THEN -- '-' range of values and '/' step values
+                a_split := regexp_split_to_array(tmp_item, '/');
+                a_range := regexp_split_to_array(a_split[1], '-');
+                a_range := array(select generate_series(a_range[1], a_range[2], a_split[2]::int));
+                a_res := array_cat(a_res, a_range);
+            ELSIF tmp_item ~ '^[*]+[\/][0-9]+$' THEN -- '*' any value and '/' step values
+                a_split := regexp_split_to_array(tmp_item, '/');
+                a_range := array(select generate_series(allowed_ranges[i_index][1], allowed_ranges[i_index][2], a_split[2]::int));
+                a_res := array_cat(a_res, a_range);
+            ELSE
+                RAISE EXCEPTION 'Value ("%") not recognized', a_element[i_index]
+                    USING HINT = 'fields separated by space or tab.'+
+                       'Values allowed: numbers (value list with ","), '+
+                    'any value with "*", range of value with "-" and step values with "/"!';
+            END IF;
+        END LOOP;
+        SELECT
+           ARRAY_AGG(x.val), MIN(x.val), MAX(x.val) INTO a_res, min_val, max_val
+        FROM (
+            SELECT DISTINCT UNNEST(a_res) AS val ORDER BY val) AS x;
+        IF max_val > allowed_ranges[i_index][2] OR min_val < allowed_ranges[i_index][1] OR a_res IS NULL THEN
+            RAISE EXCEPTION '% is out of range % for %', tmp_item, allowed_ranges[i_index:i_index][:], dimensions[i_index];
+        END IF;
+        CASE i_index
+            WHEN 1 THEN mins := a_res;
+            WHEN 2 THEN hours := a_res;
+            WHEN 3 THEN days := a_res;
+            WHEN 4 THEN months := a_res;
+        ELSE
+            dow := a_res;
+        END CASE;
+    END LOOP;
+    RETURN;
+END;
+$$ LANGUAGE PLPGSQL STRICT;
+
+ALTER DOMAIN timetable.cron
+  DROP CONSTRAINT cron_check;
+
+ALTER DOMAIN timetable.cron
+  ADD CONSTRAINT cron_check CHECK(
+    VALUE = '@reboot'
+    OR substr(VALUE, 1, 6) IN ('@every', '@after')
+       AND (substr(VALUE, 7) :: INTERVAL) IS NOT NULL
+    OR VALUE ~ '^(((\d+,)+\d+|(\d+(\/|-)\d+)|(\*(\/|-)\d+)|\d+|\*) +){4}(((\d+,)+\d+|(\d+(\/|-)\d+)|(\*(\/|-)\d+)|\d+|\*) ?)$'
+       AND timetable.cron_split_to_arrays(VALUE) IS NOT NULL
+);

--- a/internal/pgengine/sql_embed.go
+++ b/internal/pgengine/sql_embed.go
@@ -5,11 +5,14 @@ import (
 	_ "embed"
 )
 
+//go:embed sql/init.sql
+var sqlInit string
+
+//go:embed sql/cron.sql
+var sqlCron string
+
 //go:embed sql/ddl.sql
 var sqlDDL string
-
-//go:embed sql/cron_functions.sql
-var sqlCronFunctions string
 
 //go:embed sql/job_functions.sql
 var sqlJobFunctions string

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ var (
 	commit  = "000000"
 	version = "master"
 	date    = "unknown"
-	dbapi   = "00436"
+	dbapi   = "00534"
 )
 
 func printVersion() {


### PR DESCRIPTION
[-] use `cron_split_to_arrays()` function in the `cron` domain check, fixes #534
[+] add schema migration `00534`