### PR TITLE
Fix quickstart section in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,16 @@ Complete usage guide can be found in the [documentation](https://pg-timetable.re
 
 2. Make sure your **PostgreSQL** server is up and running and has a role with `CREATE` privilege for a target database, e.g.
 ```sql
-    my_database=> CREATE ROLE scheduler PASSWORD 'somestrong';
+    my_database=> CREATE ROLE scheduler PASSWORD 'somestrong' WITH LOGIN;
     my_database=> GRANT CREATE ON DATABASE my_database TO scheduler;
 ```
-3. Create a new job, e.g. run `VACUUM` each night at 00:30
+
+3. Run the pg_timetable to create **timetable** schema in your database
+```terminal
+    # pg_timetable postgresql://scheduler:somestrong@localhost/my_database --clientname=vacuumer
+```
+
+4. Create a new job, e.g. run `VACUUM` each night at 00:30
 ```sql
     my_database=> SELECT timetable.add_job('frequent-vacuum', '30 0 * * *', 'VACUUM');
     add_job
@@ -87,10 +93,7 @@ Complete usage guide can be found in the [documentation](https://pg-timetable.re
           3
     (1 row)
 ```
-4. Run the pg_timetable
-```terminal
-    # pg_timetable postgresql://scheduler:somestrong@localhost/my_database --clientname=vacuumer
-```
+
 5. PROFIT!
 
 ## Supported Environments

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -28,10 +28,17 @@ Quick Start
 
     .. code-block:: SQL
 
-      my_database=> CREATE ROLE scheduler PASSWORD 'somestrong';
+      my_database=> CREATE ROLE scheduler PASSWORD 'somestrong' WITH LOGIN;
       my_database=> GRANT CREATE ON DATABASE my_database TO scheduler;
 
-3. Create a new job, e.g. run ``VACUUM`` each night at 00:30 Postgres server time zone
+3. Run the **pg_timetable** to create **timetable** schema in your database
+
+    .. code-block::
+
+      # pg_timetable postgresql://scheduler:somestrong@localhost/my_database --clientname=vacuumer
+
+
+4. Create a new job, e.g. run ``VACUUM`` each night at 00:30 Postgres server time zone
 
     .. code-block:: SQL
 
@@ -40,12 +47,6 @@ Quick Start
       ---------
             3
       (1 row)
-
-4. Run the **pg_timetable**
-
-    .. code-block::
-
-      # pg_timetable postgresql://scheduler:somestrong@localhost/my_database --clientname=vacuumer
 
 5. PROFIT!
 


### PR DESCRIPTION
This commit is to fix quickstart section in doc

Currently in quickstart step2, role `scheduler` will be created without LOGIN
attribute. But without this attribute,  pg_timetable can not connect to the
database. This commit fix this by giving `scheduler` role LOGIN attribute

Second fix is that we need to run `pg_timetable` before creating a job, 
otherwise we won't have `timetable` schema in our database.

