### PR TITLE
[-] reset session before returning connection to the pool

### DIFF
--- a/internal/pgengine/bootstrap.go
+++ b/internal/pgengine/bootstrap.go
@@ -180,22 +180,16 @@ func (pge *PgEngine) getPgxConnConfig() *pgxpool.Config {
 		return err
 	}
 	// reset session before returning connection to the pool
-	// after task completion, if the task is not properly finalized (especially when running in autonomous mode), some objects and/or setting changes will still exist in the session
-	// if this session is then reused it can cause task failure / unintended side effects
+	// after task completion, if the task is not properly finalized (especially when running in autonomous mode),
+	// some objects and/or setting changes will still exist in the session
 	connConfig.AfterRelease = func(pgconn *pgx.Conn) bool {
-
-		batch := pgx.Batch{}
-		batch.Queue("CLOSE ALL;")
-		batch.Queue("SET SESSION AUTHORIZATION DEFAULT;")
-		batch.Queue("RESET ALL;")
-		batch.Queue("SELECT pg_advisory_unlock_all();")
-		batch.Queue("DISCARD TEMP;")
-		batch.Queue("UNLISTEN *;")
-
-		batchResult := pgconn.SendBatch(context.Background(), &batch)
-		_, err := batchResult.Exec()
+		var err error
+		if _, err = pgconn.Exec(context.Background(), "DISCARD ALL"); err == nil {
+			_, err = pgconn.Exec(context.Background(), "LISTEN "+quoteIdent(pge.ClientName))
+		}
 		return err != nil
 	}
+
 	if !pge.Start.Debug { //will handle notification in HandleNotifications directly
 		connConfig.ConnConfig.OnNotification = pge.NotificationHandler
 	}

--- a/internal/pgengine/copy_test.go
+++ b/internal/pgengine/copy_test.go
@@ -15,8 +15,12 @@ func TestCopyFromFile(t *testing.T) {
 	ctx := context.Background()
 	_, err := pge.CopyFromFile(ctx, "fake.csv", "COPY location FROM STDIN")
 	assert.Error(t, err, "Should fail for missing file")
-	_, err = pge.ConfigDb.Exec(ctx, "CREATE TEMP TABLE csv_test(id integer, val text)")
+	_, err = pge.ConfigDb.Exec(ctx, "CREATE UNLOGGED TABLE csv_test(id integer, val text)")
 	assert.NoError(t, err, "Should create temporary table")
+	defer func() {
+		_, err = pge.ConfigDb.Exec(ctx, "DROP TABLE csv_test")
+		assert.NoError(t, err, "Should drop temporary table")
+	}()
 	assert.NoError(t, os.WriteFile("test.csv", []byte("1,foo\n2,bar"), 0666), "Should create source CSV file")
 	cnt, err := pge.CopyFromFile(ctx, "test.csv", "COPY csv_test FROM STDIN (FORMAT csv)")
 	assert.NoError(t, err, "Should copy from file")


### PR DESCRIPTION
Tasks can leave objects behind after they finish executing. 
Most commonly, session scope temporary tables and advisory locks. 
Those objects persist after the connection is returned to the pool and can cause issues when the connection is reused. 

Simple example: 
Start pg_timetable with `--cron-workers=1` and create a job `SELECT timetable.add_job('tester', '* * * * *', 'create temporary table x();');`

First job run will succeed and all other runs during that connections lifetime will fail with: `ERROR: relation "x" already exists (SQLSTATE 42P07)`. 

This change also enables using `set role` in autonomous tasks as the role is reset when connection is returned to the pool. 