### PR TITLE
Use QueryRow on SELECT commands

### DIFF
--- a/internal/pgengine/transaction_test.go
+++ b/internal/pgengine/transaction_test.go
@@ -198,6 +198,24 @@ func TestExecuteSQLCommand(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestExecuteSQLCommandWithQuery(t *testing.T) {
+	initmockdb(t)
+
+	pge := pgengine.NewDB(mockPool, "pgengine_unit_test")
+
+	mockPool.ExpectQuery("select 1").WillReturnRows(pgxmock.NewRows([]string{"x"}).AddRow("1"))
+	_, err := pge.ExecuteSQLCommand(ctx, mockPool, "select 1", []string{})
+	assert.NoError(t, err)
+
+	mockPool.ExpectQuery("select public.my_function()").WillReturnRows(pgxmock.NewRows([]string{"response"}).AddRow("{\"foo\":\"bar\"}"))
+	_, err = pge.ExecuteSQLCommand(ctx, mockPool, "select public.my_function()", []string{})
+	assert.NoError(t, err)
+
+	mockPool.ExpectQuery("select with params").WithArgs("first", "second").WillReturnRows(pgxmock.NewRows([]string{"response"}).AddRow("{\"foo\":\"bar\"}"))
+	_, err = pge.ExecuteSQLCommand(ctx, mockPool, "select with params", []string{`["first", "second"]`})
+	assert.NoError(t, err)
+}
+
 func TestGetChainElements(t *testing.T) {
 	initmockdb(t)
 

--- a/internal/pgengine/types.go
+++ b/internal/pgengine/types.go
@@ -2,6 +2,7 @@ package pgengine
 
 import (
 	"context"
+	"github.com/jackc/pgx/v5"
 	"strings"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 
 type executor interface {
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (commandTag pgconn.CommandTag, err error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
 // Chain structure used to represent tasks chains


### PR DESCRIPTION
Tasks that return information about their execution always store **_SELECT 1_** in _execution_log.output_ column. This is due pgx _Exec_ method inner workings. 
Here is an idea how to store correct return value.