### PR TITLE
[+] switch to `VirtualXID` from `TransactionXID`, solves #674

### DIFF
--- a/internal/pgengine/access.go
+++ b/internal/pgengine/access.go
@@ -34,7 +34,7 @@ chain_id, task_id, command, kind, last_run, finished, returncode, pid, output, c
 VALUES ($1, $2, $3, $4, clock_timestamp() - $5 :: interval, clock_timestamp(), $6, $7, NULLIF($8, ''), $9, $10, $11)`,
 		task.ChainID, task.TaskID, task.Script, task.Kind,
 		fmt.Sprintf("%f seconds", float64(task.Duration)/1000000),
-		retCode, pge.Getsid(), strings.TrimSpace(output), pge.ClientName, task.Txid,
+		retCode, pge.Getsid(), strings.TrimSpace(output), pge.ClientName, task.Vxid,
 		task.IgnoreError)
 	if err != nil {
 		pge.l.WithError(err).Error("Failed to log chain element execution status")

--- a/internal/pgengine/transaction_test.go
+++ b/internal/pgengine/transaction_test.go
@@ -45,7 +45,7 @@ func TestStartTransaction(t *testing.T) {
 	assert.Error(t, err)
 
 	mockPool.ExpectBegin()
-	mockPool.ExpectQuery("SELECT txid_current()").WillReturnRows(pgxmock.NewRows([]string{"txid"}).AddRow(int64(42)))
+	mockPool.ExpectQuery("SELECT").WillReturnRows(pgxmock.NewRows([]string{"txid"}).AddRow(int64(42)))
 	tx, txid, err := pge.StartTransaction(ctx)
 	assert.NotNil(t, tx)
 	assert.EqualValues(t, 42, txid)

--- a/internal/pgengine/types.go
+++ b/internal/pgengine/types.go
@@ -53,7 +53,7 @@ type ChainTask struct {
 	Timeout       int         `db:"timeout"` // in milliseconds
 	StartedAt     time.Time   `db:"-"`
 	Duration      int64       `db:"-"` // in microseconds
-	Txid          int64       `db:"-"`
+	Vxid          int64       `db:"-"`
 }
 
 func (task *ChainTask) IsRemote() bool {


### PR DESCRIPTION
Turned out issuing `txid_current()` at the beginning of every chain transaction is creating a session that's sits idle in transaction for the duration of the entire chain. In current case, with a single task `{kind == PROGRAM}`, that idle transaction doesn't do anything aside from pin the `xmin` horizon and block vacuum for 6+ hours. The same issue occurs for SQL tasks that are `Remote` or `Autonomous`.