### PR TITLE
[-] fix unrecognized config parameter "pg_timetable.current_chain_id"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Binaries
 pg_timetable
-pg_timetable.exe
+*.exe
 
 # Test binary, build with `go test -c`
 *.test

--- a/internal/scheduler/chain.go
+++ b/internal/scheduler/chain.go
@@ -184,7 +184,15 @@ func (sch *Scheduler) executeOnErrorHandler(ctx context.Context, chain Chain) {
 	}
 	l := sch.l.WithField("chain", chain)
 	l.Info("Starting error handling")
-	if _, err := sch.pgengine.ConfigDb.Exec(ctx, chain.OnError); err != nil {
+	tx, _, err := sch.pgengine.StartTransaction(ctx)
+	if err != nil {
+		l.WithError(err).Info("Error handler failed")
+		return
+	}
+	sch.pgengine.SetCurrentTaskContext(ctx, tx, chain.ChainID, 0)
+	_, err = tx.Exec(ctx, chain.OnError)
+	sch.pgengine.CommitTransaction(ctx, tx)
+	if err != nil {
 		l.Info("Error handler failed")
 		return
 	}

--- a/internal/scheduler/chain_test.go
+++ b/internal/scheduler/chain_test.go
@@ -121,7 +121,11 @@ func TestExecuteOnErrorHandler(t *testing.T) {
 	sch := New(pge, log.Init(config.LoggingOpts{LogLevel: "panic", LogDBLevel: "none"}), otel.NewNoop())
 
 	t.Run("check error handler if everything is fine", func(t *testing.T) {
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT").WillReturnRows(pgxmock.NewRows([]string{"txid"}).AddRow(int64(42)))
+		mock.ExpectExec("SELECT set_config").WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).WillReturnResult(pgxmock.NewResult("SELECT", 1))
 		mock.ExpectExec("FOO").WillReturnResult(pgxmock.NewResult("FOO", 1))
+		mock.ExpectCommit()
 		sch.executeOnErrorHandler(context.Background(), c)
 		assert.NoError(t, mock.ExpectationsWereMet())
 	})
@@ -132,8 +136,17 @@ func TestExecuteOnErrorHandler(t *testing.T) {
 		sch.executeOnErrorHandler(ctx, c)
 	})
 
+	t.Run("check error handler if begin fails", func(*testing.T) {
+		mock.ExpectBegin().WillReturnError(errors.New("connection error"))
+		sch.executeOnErrorHandler(context.Background(), c)
+	})
+
 	t.Run("check error handler if error", func(*testing.T) {
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT").WillReturnRows(pgxmock.NewRows([]string{"txid"}).AddRow(int64(42)))
+		mock.ExpectExec("SELECT set_config").WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).WillReturnResult(pgxmock.NewResult("SELECT", 1))
 		mock.ExpectExec("FOO").WillReturnError(errors.New("Syntax error near FOO"))
+		mock.ExpectCommit()
 		sch.executeOnErrorHandler(context.Background(), c)
 	})
 


### PR DESCRIPTION
`executeOnErrorHandler()` did not set `pg_timetable.current_chain_id` and `current_client_name` GUCs before executing the `on_error` SQL, causing error.

Fixed by opening a transaction, calling `SetCurrentTaskContext()`, then executing the error handler SQL within it.