### PR TITLE
[+] add indexes to `timetable.execution_log`, closes #797

### DIFF
--- a/internal/pgengine/migration.go
+++ b/internal/pgengine/migration.go
@@ -159,6 +159,12 @@ var Migrations func() migrator.Option = func() migrator.Option {
 				return ExecuteMigrationScript(ctx, tx, "00792.sql")
 			},
 		},
+		&migrator.Migration{
+			Name: "00797 Add indexes to timetable.execution_log",
+			Func: func(ctx context.Context, tx pgx.Tx) error {
+				return ExecuteMigrationScript(ctx, tx, "00797.sql")
+			},
+		},
 		// adding new migration here, update "timetable"."migration" in "sql/init.sql"
 		// and "dbapi" variable in main.go!
 

--- a/internal/pgengine/sql/ddl.sql
+++ b/internal/pgengine/sql/ddl.sql
@@ -127,6 +127,38 @@ CREATE TABLE timetable.execution_log (
 
 COMMENT ON TABLE timetable.execution_log IS
     'Stores log entries of executed tasks and chains';
+COMMENT ON COLUMN timetable.execution_log.chain_id IS
+    'Link to the chain executed';
+COMMENT ON COLUMN timetable.execution_log.task_id IS
+    'Link to the task executed';
+COMMENT ON COLUMN timetable.execution_log.txid IS
+    'Transaction ID of the executed task';
+COMMENT ON COLUMN timetable.execution_log.last_run IS
+    'Timestamp of the last execution of the task';
+COMMENT ON COLUMN timetable.execution_log.finished IS
+    'Timestamp of the task execution finish';
+COMMENT ON COLUMN timetable.execution_log.pid IS
+    'Process ID of the worker executing the task';
+COMMENT ON COLUMN timetable.execution_log.returncode IS
+    'Return code of the executed task';
+COMMENT ON COLUMN timetable.execution_log.ignore_error IS
+    'Indicates whether a next task in a chain can be executed regardless of the success of the current one';
+COMMENT ON COLUMN timetable.execution_log.kind IS
+    'Indicates whether "command" is SQL, built-in function or an external program';
+COMMENT ON COLUMN timetable.execution_log.command IS
+    'Contains either an SQL command, or command string to be executed';
+COMMENT ON COLUMN timetable.execution_log.output IS
+    'Contains output of the executed task';
+COMMENT ON COLUMN timetable.execution_log.client_name IS
+    'Name of the client executing the task';
+COMMENT ON COLUMN timetable.execution_log.params IS
+    'Contains parameters passed as arguments to a chain task';
+
+CREATE INDEX execution_log_chain_id_finished_idx
+    ON timetable.execution_log (chain_id, finished);
+
+CREATE INDEX execution_log_finished_brin_idx
+    ON timetable.execution_log USING brin (finished);
 
 CREATE UNLOGGED TABLE timetable.active_chain(
     chain_id    BIGINT  NOT NULL,

--- a/internal/pgengine/sql/init.sql
+++ b/internal/pgengine/sql/init.sql
@@ -29,4 +29,5 @@ VALUES
     (13, '00629 Add ignore_error column to timetable.execution_log'),
     (14, '00721 Add more job control functions'),
     (15, '00733 Add params column to timetable.execution_log table'),
-    (16, '00792 Add ability to enable and disable tasks');
+    (16, '00792 Add ability to enable and disable tasks'),
+    (17, '00797 Add indexes to timetable.execution_log');

--- a/internal/pgengine/sql/migrations/00797.sql
+++ b/internal/pgengine/sql/migrations/00797.sql
@@ -1,0 +1,7 @@
+-- B-tree index for looking up the latest executions of a specific chain
+CREATE INDEX IF NOT EXISTS execution_log_chain_id_finished_idx
+    ON timetable.execution_log (chain_id, finished);
+
+-- BRIN index for time-window queries and retention cleanup
+CREATE INDEX IF NOT EXISTS execution_log_finished_brin_idx
+    ON timetable.execution_log USING brin (finished);

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ var (
 	commit  = "000000"
 	version = "master"
 	date    = "unknown"
-	dbapi   = "00792"
+	dbapi   = "00797"
 )
 
 func printVersion() {


### PR DESCRIPTION
- B-tree index for looking up the latest executions of a specific chain
- BRIN index for time-window queries and retention cleanup

---------

Co-authored-by: 0xgouda <gouda0x@gmail.com>