### PR TITLE
[*] update release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ SELECT timetable.add_job('reindex-job', '0 0 * * 7', 'bash',
 - Full support for database driven logging
 - Enhanced cron-style scheduling
 - Optional concurrency protection
-- **NEW**: YAML-based chain definitions for easy configuration
+- Chain and task definitions can be enabled or disabled without deleting them
+- YAML-based chain definitions for easy configuration
+- OpenTelemetry tracing and metrics export (opt-in)
+- Official Docker images published for both `linux/amd64` and `linux/arm64`
 
 ## YAML Configuration
 
@@ -83,10 +86,11 @@ chains:
         command: "CALL load_to_warehouse()"
 ```
 
-Load YAML chains with:
+Load YAML chains with one or more startup files:
 
 ```bash
 pg_timetable --file chains.yaml postgresql://user:pass@host/db
+pg_timetable --file bootstrap.sql --file chains/base.yaml --file chains/prod.yaml ******host/db
 ```
 
 See [`samples/yaml/`](samples/yaml/) for more examples and [YAML Schema](https://cybertec-postgresql.github.io/pg_timetable/latest/yaml-format/) for complete format specification.

--- a/docs/components.md
+++ b/docs/components.md
@@ -64,6 +64,16 @@ The next building block is a **task**, which simply represents a step in a list 
 | `timeout` | `integer` | Abort any task within a chain that takes more than the specified number of milliseconds |
 | `live` | `boolean` | Indication that the task is ready to run, set to `false` to skip execution (default: `true`) |
 
+You can temporarily skip a single step without deleting it by toggling the `live` flag:
+
+```sql
+UPDATE timetable.task
+SET live = FALSE
+WHERE task_id = 42;
+```
+
+For YAML-managed chains, the same behavior is available through `live: false` on an individual task.
+
 !!! warning
 
     If the **task** has been configured with `ignore_error` set to `true` (the default value is `false`), the worker process will report a success on execution *even if the task within the chain fails*.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,8 @@ It is completely database driven and provides a couple of advanced concepts.
 - Full support for database driven logging
 - Cron-style scheduling at the PostgreSQL server time zone
 - Optional concurrency protection
+- Chains and individual tasks can be enabled or disabled without deleting them
+- YAML-based chain definitions for file-based configuration
 - Task and chain can have execution timeout settings
 - OpenTelemetry tracing and metrics export (opt-in)
 
@@ -70,7 +72,10 @@ Logging:
       --log-file-number=                           Maximum number of old log files to retain, 0 to retain all (default: 0)
 
 Start:
-  -f, --file=                                      SQL script file to execute during startup
+  -f, --file=                                      SQL script or YAML chain definition file to execute during
+                                                   startup; may be specified multiple times
+      --replace                                    Replace existing chains when loading YAML files
+      --validate                                   Only validate YAML file without importing chains
       --init                                       Initialize database schema to the latest version and exit. Can be used
                                                    with --upgrade
       --upgrade                                    Upgrade database to the latest version

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,6 +29,7 @@ You may find binary package for your platform on the official [Releases](https:/
 ## Docker
 
 The official docker image can be found here: <https://hub.docker.com/r/cybertecpostgresql/pg_timetable>
+Published tags include a multi-architecture manifest for both `linux/amd64` and `linux/arm64`.
 
 !!! note
 

--- a/docs/yaml-usage-guide.md
+++ b/docs/yaml-usage-guide.md
@@ -14,8 +14,11 @@ YAML chain definitions provide a human-readable way to create scheduled task cha
 ## Basic Usage
 
 ```bash
-# Load YAML chains
+# Load a single YAML file
 pg_timetable --file chains.yaml postgresql://user:pass@host/db
+
+# Load several startup files in order
+pg_timetable --file bootstrap.sql --file chains/base.yaml --file chains/prod.yaml ******host/db
 
 # Validate YAML without importing
 pg_timetable --file chains.yaml --validate
@@ -23,6 +26,8 @@ pg_timetable --file chains.yaml --validate
 # Replace existing chains with same names
 pg_timetable --file chains.yaml --replace postgresql://user:pass@host/db
 ```
+
+Each `--file` value is processed in the order provided, so you can mix SQL bootstrap scripts and YAML chain definitions in one startup command.
 
 ## YAML Format
 
@@ -48,6 +53,7 @@ chains:
         ignore_error: false            # Optional: continue on error
         autonomous: false              # Optional: run outside transaction
         timeout: 5000                  # Optional: task timeout in ms
+        live: true                     # Optional: set false to keep the task but skip execution
         parameters:                    # Optional: task parameters, each entry causes separate execution
           - ["value1", 42]             # Parameters for SQL tasks are arrays of values
 ```
@@ -200,6 +206,26 @@ chains:
       - command: "DELETE FROM logs WHERE created_at < now() - interval '7 days'"
 ```
 
+#### Disabling a Task Without Removing It
+
+```yaml
+chains:
+  - name: "maintenance-window"
+    schedule: "0 1 * * *"
+    live: true
+
+    tasks:
+      - name: "pre-check"
+        command: "SELECT run_precheck()"
+      - name: "paused-step"
+        command: "SELECT run_optional_step()"
+        live: false
+      - name: "post-check"
+        command: "SELECT run_postcheck()"
+```
+
+Tasks with `live: false` remain part of the chain definition but are skipped until re-enabled.
+
 ## Advanced Features
 
 ### Error Handling
@@ -259,10 +285,10 @@ YAML files are validated when loaded:
 - **Task kinds**: Must be SQL, PROGRAM, or BUILTIN
 - **Timeouts**: Non-negative integers
 
-Use `--validate` to check files without importing:
+Use `--validate` to check one or more YAML files without importing:
 
 ```bash
-pg_timetable --file chains.yaml --validate
+pg_timetable --file chains/base.yaml --file chains/prod.yaml --validate
 ```
 
 ## Migration from SQL


### PR DESCRIPTION
The upcoming release adds several user-visible capabilities, but the public docs did not describe them consistently yet. This refresh brings the README and MkDocs pages back in sync with the current release behavior so users can discover and use the new options directly from the documentation.

## What changed

- refreshed the feature summaries in the README and docs index to mention task enable/disable support, YAML-based configuration, OpenTelemetry support, and Docker arm64 availability
- updated the CLI documentation for repeatable `--file` usage and the YAML-specific `--replace` and `--validate` flags
- expanded the YAML and task documentation with examples for loading multiple startup files and disabling individual tasks with `live: false`
- clarified Docker image availability for both `linux/amd64` and `linux/arm64`
