### PR TITLE
Fix star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,4 +194,4 @@ For professional support, please contact [Cybertec](https://www.cybertec-postgre
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=cybertec-postgresql/pg_timetable&type=Date)](https://star-history.com/#cybertec-postgresql/pg_timetable&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=cybertec-postgresql/pg_timetable&type=Date)](https://star-history.dera.page/#cybertec-postgresql/pg_timetable&Date)


### PR DESCRIPTION
The star history chart shown in the README is broken because of GitHub stargazer API restrictions, so the visualization no longer renders. This change repoints the chart to a working source that needs no API token and keeps both the embedding and the click-through link on the same domain.