### PR TITLE
[-] fix `PROGRAM` task error exit code always logged as -1, fixes #827

### DIFF
--- a/internal/pgengine/secrets.go
+++ b/internal/pgengine/secrets.go
@@ -108,11 +108,8 @@ func isWrongKey(err error) bool {
 // (feature_not_supported) raised by timetable.resolve_secret when the
 // pgcrypto extension is not installed.
 func isMissingPgcrypto(err error) bool {
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
-		return pgErr.Code == "0A000"
-	}
-	return false
+	pgErr, ok := errors.AsType[*pgconn.PgError](err)
+	return ok && pgErr.Code == "0A000"
 }
 
 func uniqueRefNames(s string) []string {

--- a/internal/scheduler/shell.go
+++ b/internal/scheduler/shell.go
@@ -60,10 +60,10 @@ func (sch *Scheduler) ExecuteProgramCommand(ctx context.Context, task *pgengine.
 		out, e := Cmd.CombinedOutput(ctx, command, params...) // #nosec
 		if e != nil {
 			exitCode = -1
-			err = errors.Join(err, e) // accumulate errors for all param sets
-			if exitError, ok := err.(*exec.ExitError); ok {
-				exitCode = exitError.ExitCode()
+			if exitErr, isOK := errors.AsType[*exec.ExitError](e); isOK {
+				exitCode = exitErr.ExitCode()
 			}
+			err = errors.Join(err, e) // accumulate errors for all param sets
 		}
 		sch.pgengine.LogTaskExecution(context.Background(), task, exitCode, string(out), val)
 	}


### PR DESCRIPTION
`ExecuteProgramCommand()` type-asserted the accumulated err (an `errors.Join` result) against `*exec.ExitError`. Since `errors.Join` wraps even a single non-nil error in a `*joinError`, the assertion never succeeded and `exit_code = -1` was logged for every failure, regardless of the real process exit status.

Assert on the immediate command error `e` with `errors.AsType` instead, so the actual exit code is recorded.

Fixes #827