### PR TITLE
[*] document NULL schedule behavior, fixes #833

### DIFF
--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -25,7 +25,7 @@ Creates a simple one-task chain
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
 | `job_name` | `text` | The unique name of the **chain** and **command** | Required |
-| `job_schedule` | `timetable.cron` | Time schedule in сron syntax at Postgres server time zone | Required |
+| `job_schedule` | `timetable.cron` | Time schedule in cron syntax at Postgres server time zone. If `NULL`, the chain runs every minute | Required |
 | `job_command` | `text` | The SQL which will be executed | Required |
 | `job_parameters` | `jsonb` | Arguments for the chain **command** | `NULL` |
 | `job_kind` | `timetable.command_kind` | Kind of the command: *SQL*, *PROGRAM* or *BUILTIN* | `SQL` |

--- a/docs/explanation-scheduling-model.md
+++ b/docs/explanation-scheduling-model.md
@@ -8,4 +8,7 @@ The scheduling in **pg_timetable** encompasses three different abstraction level
 
 **Chain:** The third level represents a connected tasks forming a chain of tasks. **Chain** defines *if*, *when*, and *how often* a job should be executed.
 
+!!! note
+    If a chain's `run_at` (schedule) is `NULL`, it will execute on every scheduler tick (by default, every minute). This is equivalent to a `* * * * *` cron schedule.
+
 The exact fields, kinds, and parameter formats for each level are documented in the [Commands, Tasks, and Chains Reference](reference-commands-tasks-chains.md).

--- a/docs/reference-commands-tasks-chains.md
+++ b/docs/reference-commands-tasks-chains.md
@@ -235,7 +235,7 @@ Once tasks have been arranged, they have to be scheduled as a **chain**. For thi
 | Field | Type | Description |
 |-------|------|-------------|
 | `chain_name` | `text` | The unique name of the chain |
-| `run_at` | `timetable.cron` | Standard *cron*-style value at Postgres server time zone or `@after`, `@every`, `@reboot` clause |
+| `run_at` | `timetable.cron` | Standard *cron*-style value at Postgres server time zone or `@after`, `@every`, `@reboot` clause. If `NULL`, the chain runs every minute |
 | `max_instances` | `integer` | The amount of instances that this chain may have running at the same time |
 | `timeout` | `integer` | Abort any chain that takes more than the specified number of milliseconds |
 | `live` | `boolean` | Control if the chain may be executed once it reaches its schedule |

--- a/docs/yaml-format.md
+++ b/docs/yaml-format.md
@@ -45,7 +45,7 @@ chains:
 | YAML Field | DB Column | Type | Default | Description |
 |------------|-----------|------|---------|-------------|
 | `name` | `chain_name` | TEXT | **required** | Unique chain identifier |
-| `schedule` | `run_at` | cron | **required** | Cron-style schedule |
+| `schedule` | `run_at` | cron | **required** | Cron-style schedule. If omitted or empty, defaults to `* * * * *` (every minute) |
 | `live` | `live` | BOOLEAN | `false` | Whether chain is active |
 | `max_instances` | `max_instances` | INTEGER | `null` | Max parallel instances |
 | `timeout` | `timeout` | INTEGER | `0` | Chain timeout (ms) |


### PR DESCRIPTION
If the run_at is set to NULL it is the same
as setting to run every minute

Closes #833